### PR TITLE
feat: 增加对 markdown 链接的特别偏好设置

### DIFF
--- a/doc/pangu.txt
+++ b/doc/pangu.txt
@@ -74,6 +74,15 @@ RULES                                                *pangu-rules*
   let g:pangu_rule_fullwidth_punctuation = 0
 <
 
+                                       *g:pangu_rule_fullwidth_punctuation_link*
+
+自动修复 markdown 链接中的中文括号。
+
+如需关闭可以设置： >
+  let g:pangu_rule_fullwidth_punctuation_link = 0
+<
+
+
                                        *g:pangu_rule_duplicate_punctuation*
 
 连续重复的标点符号规则。根据中华人民共和国国家标准：标点符号用法 GB/T 15834-2011

--- a/plugin/pangu.vim
+++ b/plugin/pangu.vim
@@ -13,6 +13,9 @@ endif
 if !exists("g:pangu_rule_fullwidth_punctuation")
   let g:pangu_rule_fullwidth_punctuation=1
 endif
+if !exists("g:pangu_rule_fullwidth_punctuation_link")
+  let g:pangu_rule_fullwidth_punctuation_link=1
+endif
 if !exists("g:pangu_rule_duplicate_punctuation")
   let g:pangu_rule_duplicate_punctuation=1
 endif
@@ -101,8 +104,13 @@ function! PanGuSpacingCore(mode) range
     " 双半角书名号 `<<名称>>` 特殊修复处理
     silent! execute firstline . ',' . lastline . 's/<《/《/g'
     silent! execute firstline . ',' . lastline . 's/》>/》/g'
+  endif
 
-    " 修复 markdown 链接所使用的标点。
+  " 修复 markdown 链接所使用的标点。
+  if g:pangu_rule_fullwidth_punctuation_link == 1
+    let bracket_left = g:pangu_punctuation_brackets[0]
+    let bracket_right = g:pangu_punctuation_brackets[1]
+
     " 参考链接
     silent! execute firstline . ',' . lastline . 's/[' . bracket_left . '[]\([^' . bracket_right . '\]]\+\)[' . bracket_right . '\]][' . bracket_left . '[]\([^' . bracket_right . '\]]\+\)[' . bracket_right . '\]]/[\1][\2]/g'
     " 内联链接

--- a/test/brackets.txt
+++ b/test/brackets.txt
@@ -26,6 +26,8 @@
 
 wiki 链接 [http://www.example.com/ 示例]
 
+【链接】（www.example.com)
+[【内容】内容](https://www.example.com/)
 
 
 无嵌套书名号：


### PR DESCRIPTION
在关闭 `g:pangu_rule_fullwidth_punctuation` 时可以在牺牲一部分功能下解决
issue #46 而不引入其它问题（issue #49）。

私以为关闭 `g:pangu_rule_fullwidth_punctuation` 不会影响主要用例。`pangu.vim` 解决的主要问题个人感觉是以中文为主要语言时写 markdown。既然中文是主要语言，那么输入中文紧接着输入英文标点（逗号句号等）的需求应该是不常见的。更多的麻烦在输入 markdown 链接时需要频繁切换中英文。既然这两个需求具有不同的使用频率，不如将决定是否执行操作的变量分为两个 `g:pangu_rule_fullwidth_punctuation` 和 `g:pangu_rule_fullwidth_punctuation_link`，分别控制两个需求。

我在 `test/brackets.txt` 里加了两个测试用例，可以看到，在关闭 `g:pangu_rule_fullwidth_punctuation` 的同时开启 `g:pangu_rule_fullwidth_punctuation_link` 时，这两个用例的输出都是正确的。

谢谢